### PR TITLE
Update SDK version to 8.0.410

### DIFF
--- a/release-notes/8.0/8.0.16/8.0.16.md
+++ b/release-notes/8.0/8.0.16/8.0.16.md
@@ -647,7 +647,7 @@ System.Net.Http.WinHttpHandler | 8.0.3
 [aspnetcore-runtime-win-x86.exe]: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.16/aspnetcore-runtime-8.0.16-win-x86.exe
 [dotnet-hosting-win.exe]: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.16/dotnet-hosting-8.0.16-win.exe
 
-[//]: # ( SDK 8.0.409)
+[//]: # ( SDK 8.0.410)
 [dotnet-sdk-linux-arm.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-arm.tar.gz
 [dotnet-sdk-linux-arm64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-arm64.tar.gz
 [dotnet-sdk-linux-musl-arm.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-musl-arm.tar.gz

--- a/release-notes/8.0/8.0.16/8.0.16.md
+++ b/release-notes/8.0/8.0.16/8.0.16.md
@@ -33,7 +33,7 @@ You can check your .NET SDK version by running the following command. The exampl
 
 ```console
 $ dotnet --version
-8.0.409
+8.0.410
 ```
 
 ## Docker Images
@@ -648,18 +648,18 @@ System.Net.Http.WinHttpHandler | 8.0.3
 [dotnet-hosting-win.exe]: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.16/dotnet-hosting-8.0.16-win.exe
 
 [//]: # ( SDK 8.0.409)
-[dotnet-sdk-linux-arm.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-linux-arm.tar.gz
-[dotnet-sdk-linux-arm64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-linux-arm64.tar.gz
-[dotnet-sdk-linux-musl-arm.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-linux-musl-arm.tar.gz
-[dotnet-sdk-linux-musl-x64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-linux-musl-x64.tar.gz
-[dotnet-sdk-linux-x64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-linux-x64.tar.gz
-[dotnet-sdk-osx-arm64.pkg]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-osx-arm64.pkg
-[dotnet-sdk-osx-arm64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-osx-arm64.tar.gz
-[dotnet-sdk-osx-x64.pkg]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-osx-x64.pkg
-[dotnet-sdk-osx-x64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-osx-x64.tar.gz
-[dotnet-sdk-win-arm64.exe]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-win-arm64.exe
-[dotnet-sdk-win-arm64.zip]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-win-arm64.zip
-[dotnet-sdk-win-x64.exe]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-win-x64.exe
-[dotnet-sdk-win-x64.zip]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-win-x64.zip
-[dotnet-sdk-win-x86.exe]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-win-x86.exe
-[dotnet-sdk-win-x86.zip]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.409/dotnet-sdk-8.0.409-win-x86.zip
+[dotnet-sdk-linux-arm.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-arm.tar.gz
+[dotnet-sdk-linux-arm64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-arm64.tar.gz
+[dotnet-sdk-linux-musl-arm.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-musl-arm.tar.gz
+[dotnet-sdk-linux-musl-x64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-musl-x64.tar.gz
+[dotnet-sdk-linux-x64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-linux-x64.tar.gz
+[dotnet-sdk-osx-arm64.pkg]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-osx-arm64.pkg
+[dotnet-sdk-osx-arm64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-osx-arm64.tar.gz
+[dotnet-sdk-osx-x64.pkg]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-osx-x64.pkg
+[dotnet-sdk-osx-x64.tar.gz]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-osx-x64.tar.gz
+[dotnet-sdk-win-arm64.exe]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-win-arm64.exe
+[dotnet-sdk-win-arm64.zip]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-win-arm64.zip
+[dotnet-sdk-win-x64.exe]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-win-x64.exe
+[dotnet-sdk-win-x64.zip]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-win-x64.zip
+[dotnet-sdk-win-x86.exe]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-win-x86.exe
+[dotnet-sdk-win-x86.zip]: https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.410/dotnet-sdk-8.0.410-win-x86.zip


### PR DESCRIPTION
#### PR Classification
Update to the .NET SDK version and associated runtime packages.

#### PR Summary
The .NET SDK has been upgraded from version 8.0.409 to 8.0.410, including updates to runtime and SDK packages for multiple platforms. 
- Updated SDK version in documentation from 8.0.409 to 8.0.410.
- Added new download links for SDK and runtime packages for Linux, macOS, and Windows.
- Removed outdated download links for SDK and runtime packages for version 8.0.409.
